### PR TITLE
Fix compatible ResponseTestCase

### DIFF
--- a/src/ResponseTestCase.php
+++ b/src/ResponseTestCase.php
@@ -17,8 +17,6 @@ use Throwable;
  */
 class ResponseTestCase extends TestResponse
 {
-    use Debugging;
-
     /**
      * The exception thrown in the response.
      *


### PR DESCRIPTION
`Fatal error: Declaration of Illuminate\Testing\Fluent\Concerns\Debugging::dump(?string $prop = null) must be compatible with Illuminate\Testing\TestResponse::dump($key = null) in `